### PR TITLE
Disable no-implicit-dependencies

### DIFF
--- a/tslint.js
+++ b/tslint.js
@@ -18,6 +18,7 @@ module.exports = {
         "jsx-no-multiline-js": false,
         "max-classes-per-file": [false],
         "no-empty": false,
+        "no-implicit-dependencies": false,
         "no-reference": false,
         "no-unused-expression": false,
         "no-unused-variable": true,


### PR DESCRIPTION
- Ignores peerDeps, which really sucks for our libraries, as we don't want them to force a specific react/stylable version.
- Cannot work in our current tests setup, as we use "devDependencies" packages in our tests (chai, sinon, etc.)

closes #9