### PR TITLE
Added rule to prevent committing .only calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "license": "ISC",
   "dependencies": {
     "tslint-eslint-rules": "^4.1.1",
+    "tslint-microsoft-contrib": "^5.0.1",
     "tslint-react": "^3.1.0"
   },
   "peerDependencies": {

--- a/tslint.js
+++ b/tslint.js
@@ -7,7 +7,7 @@ module.exports = {
     ],
     "rulesDirectory": [
         path.join(path.dirname(require.resolve('tslint-eslint-rules')), 'dist/rules'),
-        path.join(path.dirname(require.resolve('tslint-microsoft-contrib'))),
+        'node_modules/tslint-microsoft-contrib'
     ],
     "rules": {
         "arrow-parens": [true, "ban-single-arg-parens"],

--- a/tslint.js
+++ b/tslint.js
@@ -7,7 +7,7 @@ module.exports = {
     ],
     "rulesDirectory": [
         path.join(path.dirname(require.resolve('tslint-eslint-rules')), 'dist/rules'),
-        'node_modules/tslint-microsoft-contrib'
+        path.join(path.dirname(require.resolve('tslint-microsoft-contrib')))
     ],
     "rules": {
         "arrow-parens": [true, "ban-single-arg-parens"],

--- a/tslint.js
+++ b/tslint.js
@@ -6,7 +6,8 @@ module.exports = {
         "tslint-react"
     ],
     "rulesDirectory": [
-        path.join(path.dirname(require.resolve('tslint-eslint-rules')), 'dist/rules')
+        path.join(path.dirname(require.resolve('tslint-eslint-rules')), 'dist/rules'),
+        path.join(path.dirname(require.resolve('tslint-microsoft-contrib'))),
     ],
     "rules": {
         "arrow-parens": [true, "ban-single-arg-parens"],
@@ -17,6 +18,7 @@ module.exports = {
         "jsx-boolean-value": false,
         "jsx-no-multiline-js": false,
         "max-classes-per-file": [false],
+        "mocha-avoid-only": true,
         "no-empty": false,
         "no-implicit-dependencies": false,
         "no-reference": false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -29,6 +29,12 @@ tslint-eslint-rules@^4.1.1:
     tslib "^1.0.0"
     tsutils "^1.4.0"
 
+tslint-microsoft-contrib@^5.0.1:
+  version "5.0.1"
+  resolved "http://npmreg.wixcore3.com/tslint-microsoft-contrib/-/tslint-microsoft-contrib-5.0.1.tgz#328ee9c28d07cdf793293204c96e2ffab9221994"
+  dependencies:
+    tsutils "^1.4.0"
+
 tslint-react@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/tslint-react/-/tslint-react-3.2.0.tgz#851fb505201c63d0343c51726e6364f7e9ad2e99"


### PR DESCRIPTION
| Rule Name | Link to the Description | Short Description |
|-----------|-------------------------|-------------------|
|      mocha-avoid-only     |     [mocha-avoid-only](https://github.com/Microsoft/tslint-microsoft-contrib)                    |        Do not invoke Mocha's describe.only, it.only or context.only functions. These functions are useful ways to run a single unit test or a single test case during your build, but please be careful to not push these methods calls to your version control repositiory because it will turn off any of the other tests.          |

Upvoted issue: #11 
